### PR TITLE
Add GetSepolia faucet

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The `--sepolia` cross-client proof-of-authority testnet configuration. Sepolia r
   - https://learnweb3.io/faucets/sepolia (LearnWeb3's free faucet)
   - https://infura.io/faucet
   - https://unitap.app/gastap
+  - https://getsepolia.2bd.net
 - Open RPC Endpoints:
   - https://rpc.sepolia.online
   - https://www.sepoliarpc.space


### PR DESCRIPTION
Adds GetSepolia to the Sepolia faucet list.

GetSepolia is a free, open-source Sepolia faucet providing 0.02 Sepolia ETH every 24 hours without requiring an account, wallet connection, or mainnet balance.

Thanks for maintaining the Sepolia resources!